### PR TITLE
Added sort by date functionality to history page

### DIFF
--- a/src/_metronic/_partials/widgets/yup/YupFeedTableWidget.js
+++ b/src/_metronic/_partials/widgets/yup/YupFeedTableWidget.js
@@ -18,11 +18,14 @@ class YupFeedTableWidget extends Component {
       error: null,
       isLoaded: false,
       items: { 1:null,2:null,3:null,4:null,5:null},
-      page: 1
+      page: 1,
+      //Adding sortOrder to change the order, true is descending and false is ascending
+      sortOrder: true,
     };
     this.updateData = this.updateData.bind(this);
     this.getCreateVoteV3 = this.getCreateVoteV3.bind(this);
     this.getPostVoteV2 = this.getPostVoteV2.bind(this);
+    this.changeOrder = this.changeOrder.bind(this);
   }
 
   componentDidMount() {
@@ -34,7 +37,16 @@ class YupFeedTableWidget extends Component {
 
     let [createVoteV3,postVoteV2]= await Promise.all([this.getCreateVoteV3(0,limit), this.getPostVoteV2(0,limit)]);
     let allVotes = createVoteV3.actions.concat(postVoteV2.actions)
-    allVotes.sort(function(a, b){return new Date(b.timestamp) - new Date(a.timestamp)});
+    //Checking to see the current desired sorting order
+    if (this.sortOrder) {
+      allVotes.sort(function(a, b) {
+        return new Date(b.timestamp) - new Date(a.timestamp);
+      });
+    } else {
+      allVotes.sort(function(a, b) {
+        return new Date(a.timestamp) - new Date(b.timestamp);
+      });
+    }
     allVotes.forEach(item => {
       item.timestamp = this.convertUTCDateToLocalDate(new Date(item.timestamp))
     })
@@ -122,7 +134,21 @@ class YupFeedTableWidget extends Component {
       }
       itemsProcessed++;
       if(itemsProcessed === items.length) {
-        fullData.sort(function(a, b){return new Date(b.vote.timestamp).getTime() - new Date(a.vote.timestamp).getTime()});
+        if (this.sortOrder) {
+          fullData.sort(function(a, b) {
+            return (
+              new Date(b.vote.timestamp).getTime() -
+              new Date(a.vote.timestamp).getTime()
+            );
+          });
+        } else {
+          fullData.sort(function(a, b) {
+            return (
+              new Date(a.vote.timestamp).getTime() -
+              new Date(b.vote.timestamp).getTime()
+            );
+          });
+        }
         let newItems = this.state.items
         newItems[page] = fullData
         this.setState({
@@ -199,6 +225,12 @@ class YupFeedTableWidget extends Component {
   createPagination(){
 
   }
+  //Method for updating the order
+  changeOrder() {
+    this.sortOrder = !this.sortOrder;
+    this.updateData(1, 50);
+  }
+
   render() {
     const { error, isLoaded, items } = this.state;
     if (error) {
@@ -221,7 +253,7 @@ class YupFeedTableWidget extends Component {
                 <table className="table table-head-custom  table-borderless table-vertical-center">
                   <thead>
                     <tr className="text-left">
-                      <th className="text-left">Time</th>
+                      <th className="text-left" id="time" onClick={() => this.changeOrder()}>Time</th>
                       <th className="text-left">User</th>
                       <th >Content</th>
                       <th className="text-left">Rating</th>

--- a/src/_metronic/_partials/widgets/yup/custom.css
+++ b/src/_metronic/_partials/widgets/yup/custom.css
@@ -131,3 +131,8 @@ a{
   border-radius: 10px;
   font-weight: 500;
 }
+
+#time {
+  text-decoration: underline;
+  cursor: pointer;
+}


### PR DESCRIPTION
- I've added the ability to sort results on the history page by clicking the Time table header
- I figured this could be useful for users that want to see older data
- To accomplish this, I created state that tracks how the data should be sorted
- I then created a method that would update this state and re-render the data
- I added an event listener to the Time header in the table and I underlined the Time header and added the cursor: pointer; 
  formatting to make it obvious that clicking the Time header does something